### PR TITLE
Add missing class to the navbar toggle button

### DIFF
--- a/module/templates/navbar_toggle.html5
+++ b/module/templates/navbar_toggle.html5
@@ -1,4 +1,4 @@
-<button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-responsive-<?php echo $this->id; ?>">
+<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-responsive-<?php echo $this->id; ?>">
   <span class="invisible"><?php echo $GLOBALS['TL_LANG']['MSC']['bootstrapToggleNavigation']; ?></span>
   <span class="icon-bar"></span>
   <span class="icon-bar"></span>


### PR DESCRIPTION
The navbar toggle button should have the class `collapsed` as start value.
